### PR TITLE
Add Analog Garage event for Boston May 2026

### DIFF
--- a/content/boston.md
+++ b/content/boston.md
@@ -26,6 +26,8 @@ May 21, 2026 @ 7:00 pm - 9:00 pm
 ## RSVP
 Please RSVP at the <a href="https://luma.com/q7fpx3ol">Luma here</a>
 
+<iframe src="https://lu.ma/embed-checkout/q7fpx3ol" width="100%" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+
 ## Access
 If you arrive after 7:00 pm, send a text to \
 

--- a/content/boston.md
+++ b/content/boston.md
@@ -4,43 +4,26 @@ title = "🫘🌆 Boston"
 <!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
 
 ## Where
-<!-- TBD -->
-<a href="https://rai-inst.com/">
-  <!-- light version -->
-  <img
-    src="/images/logos/rai-logo-light.svg"
-    alt="Robotics and AI Institute Logo"
-    class="logo-light"
-  >
-  <!-- dark version -->
-  <img
-    src="/images/logos/rai-logo-dark.svg"
-    alt="Robotics and AI Institute Logo"
-    class="logo-dark"
-  >
-</a>
+[![venue logo](/images/logos/analog-devices-logo.jpg)](https://www.analog.com/)
 
-**Robotics and AI Institute** \
-**145 Broadway** \
-**Cambridge, MA 02142**
+**Analog Devices** \
+**125 Summer St** \
+**Boston, MA 02110**
 
-The hosts will be collecting people from the lobby and bringing them to where games will be hosted. \
-The AI Institute will provide pizza, snacks, and non alcoholic beverages. \
-The event is alcohol free. \
-Pizza and games will be provided but feel free to bring your own to share! \
-Photographs will not be allowed to be taken. \
+Analog Devices is welcoming its fellow Bostonian's to a night of fun and games!
+Currently, the organization has to limit the attendance to 48 participants so be sure to RSVP! \
+The names of each attendee must be given by the day before so badges can be made. \
+Pizza and games will be provided but feel free to bring your own to share!
 
 ## When
-March 26, 2026 @ 6:30 pm
+May 21, 2026 @ 7:00 pm - 9:00 pm
 
 ## RSVP
-<a href="https://forms.gle/cUZbYJTcFeKSYcgU9">Please RSVP here</a> \
-Names and emails for all attendees are required. You will be emailed a form to fill out before the event and will receive a QR code to scan at the front desk when you arrive.
-{% admonition(kind="note") %}
-Each attendee should RSVP separately.
-{% end %}
+<a href="https://forms.gle/aE4pVCXK6s2io5RQA">RSVP Google Form</a>
 
 ## Access
-The RAI Institute is located in the Akamai building. The entrance is on the side facing construction.
+If you arrive after 7:00 pm, send a text to \
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2947.9491618245934!2d-71.088803!3d42.3649227!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89e371004f084101%3A0x865f42b145478533!2sRAI%20Institute!5e0!3m2!1sen!2sus!4v1753812098522!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+(617) 744-9296 \
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2948.506380455931!2d-71.0575037!3d42.3530464!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89e370a500000001%3A0x57f7113f59f1d20d!2sAnalog%20Devices!5e0!3m2!1sen!2sus!4v1750903406736!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/content/boston.md
+++ b/content/boston.md
@@ -24,7 +24,7 @@ Photographs are welcome!
 May 21, 2026 @ 7:00 pm - 9:00 pm
 
 ## RSVP
-<a href="https://forms.gle/aE4pVCXK6s2io5RQA">RSVP Google Form</a>
+Please RSVP at the <a href="https://luma.com/q7fpx3ol">Luma here</a>
 
 ## Access
 If you arrive after 7:00 pm, send a text to \

--- a/content/boston.md
+++ b/content/boston.md
@@ -10,10 +10,11 @@ title = "🫘🌆 Boston"
 **125 Summer St** \
 **Boston, MA 02110**
 
-Analog Devices is welcoming its fellow Bostonian's to a night of fun and games!
+Analog Devices is welcoming its fellow Bostonians to a night of fun and games!
 Currently, the organization has to limit the attendance to 48 participants so be sure to RSVP! \
 The names of each attendee must be given by the day before so badges can be made. \
-Pizza and games will be provided but feel free to bring your own to share!
+Pizza and games will be provided but feel free to bring your own to share! \
+Photographs are welcome!
 
 ## When
 May 21, 2026 @ 7:00 pm - 9:00 pm

--- a/content/boston.md
+++ b/content/boston.md
@@ -10,11 +10,14 @@ title = "🫘🌆 Boston"
 **125 Summer St** \
 **Boston, MA 02110**
 
-The Analog Garage is Analog Devices' innovation hub, where teams prototype emerging tech at the edge of sensing, signal processing, and AI. \
-Analog Devices is welcoming its fellow Bostonians to a night of fun and games!
-Currently, the organization has to limit the attendance to 48 participants so be sure to RSVP! \
-The names of each attendee must be given by the day before so badges can be made. \
-Pizza and games will be provided but feel free to bring your own to share! \
+Analog Garage @ Analog Devices is welcoming its fellow Bostonians to a night of fun and games! The Analog Garage is Analog Devices' innovation hub, where teams prototype emerging tech at the edge of sensing, signal processing, and AI.
+
+Currently, the organization has to limit the attendance to 48 participants so be sure to RSVP!
+
+The names of each attendee must be given by the day before so badges can be made.
+
+Pizza and games will be provided but feel free to bring your own to share!
+
 Photographs are welcome!
 
 ## When

--- a/content/boston.md
+++ b/content/boston.md
@@ -10,6 +10,7 @@ title = "🫘🌆 Boston"
 **125 Summer St** \
 **Boston, MA 02110**
 
+The Analog Garage is Analog Devices' innovation hub, where teams prototype emerging tech at the edge of sensing, signal processing, and AI. \
 Analog Devices is welcoming its fellow Bostonians to a night of fun and games!
 Currently, the organization has to limit the attendance to 48 participants so be sure to RSVP! \
 The names of each attendee must be given by the day before so badges can be made. \

--- a/content/boston.md
+++ b/content/boston.md
@@ -1,10 +1,36 @@
 +++
 title = "🫘🌆 Boston"
 +++
-[![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston)
+<!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
 
 ## Where
-TBD
+[![venue logo](/images/logos/analog-devices-logo.jpg)](https://www.analog.com/)
+
+**Analog Devices** \
+**125 Summer St** \
+**Boston, MA 02110**
+
+Analog Garage @ Analog Devices is welcoming its fellow Bostonians to a night of fun and games! The Analog Garage is Analog Devices' innovation hub, where teams prototype emerging tech at the edge of sensing, signal processing, and AI.
+
+Currently, the organization has to limit the attendance to 48 participants so be sure to RSVP!
+
+The names of each attendee must be given by the day before so badges can be made.
+
+Pizza and games will be provided but feel free to bring your own to share!
+
+Photographs are welcome!
 
 ## When
-TBD
+May 21, 2026 @ 7:00 pm - 9:00 pm
+
+## RSVP
+Please RSVP at the <a href="https://luma.com/q7fpx3ol">Luma here</a>
+
+<iframe src="https://lu.ma/embed-checkout/q7fpx3ol" width="100%" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+
+## Access
+If you arrive after 7:00 pm, send a text to \
+
+(617) 744-9296 \
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2948.506380455931!2d-71.0575037!3d42.3530464!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89e370a500000001%3A0x57f7113f59f1d20d!2sAnalog%20Devices!5e0!3m2!1sen!2sus!4v1750903406736!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>


### PR DESCRIPTION
## Summary
- Add Analog Garage @ Analog Devices (125 Summer St, Boston) as the Boston May 2026 venue
- Event date: May 21, 2026 @ 7:00 pm - 9:00 pm
- Details carried over from July 2025 event: 48 person cap, badges needed day before, pizza provided, late arrival text number, Google Maps embed
- RSVP via Google Form

## No TBD items
All details filled in from previous event history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)