### PR TITLE
Fix broken images: enable Git LFS in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Build
         uses: shalzz/zola-deploy-action@v0.17.2


### PR DESCRIPTION
## Summary
- Add `lfs: true` to the `actions/checkout` step in the deploy workflow
- Since PR #58 enabled LFS for PNG/JPG files, all images have been deploying as LFS pointer files instead of actual binaries, breaking every image on the site

## Test plan
- [ ] Merge and verify images load on boardgamenightwg.com (header logo, Boston/Bay Area venue logos, past event images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)