### PR TITLE
Add unified Luma calendar embed to home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,5 +6,7 @@ title = "Home"
 ## [🌅🌉 Bay Area](/bayarea/)
 ## [🫘🌆 Boston](/boston/)
 
+# Upcoming Events
+<iframe src="https://lu.ma/embed/calendar/cal-v6H3Jm84BrwuOYb/events" width="100%" height="600" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
 
 ### [Established in 2012](/about/) @ Willow Garage in Menlo Park, CA


### PR DESCRIPTION
## Summary
- Embed the boardgamenightwg Luma calendar (`cal-v6H3Jm84BrwuOYb`) on the home page so visitors can see all upcoming chapter events at a glance
- Adds an "Upcoming Events" section between "Current Chapters" and the founding line

## Test plan
- [ ] Confirm the calendar iframe renders on the deployed home page
- [ ] Confirm upcoming events from Boston / Bay Area show up once they're added to the Luma calendar
- [ ] Adjust height (currently 600px) if it crops the events list

🤖 Generated with [Claude Code](https://claude.com/claude-code)