### PR TITLE
Close Tutor Intelligence registration (at capacity)

### DIFF
--- a/content/boston.md
+++ b/content/boston.md
@@ -32,9 +32,8 @@ Games will be provided but feel free to bring your own to share!
 April 30, 2026 @ 6:00 pm - 8:30 pm
 
 ## RSVP
-Please RSVP at the <a href="https://luma.com/7ahfm9ii">Luma here</a>
+**Registration is now closed. We've reached capacity for this event. Thank you to everyone who registered!**
 
-Names, emails, and companies of all attendees are required for registration. Registration closes at noon on April 30. \
 NDA signature is required. A kiosk will be available at the location to fill it out.
 
 ## Access


### PR DESCRIPTION
## Summary
- Close registration for the April 30, 2026 Tutor Intelligence Boston event since we've hit capacity
- Replace the Luma RSVP link with a clear "registration closed" notice
- Keep the NDA reminder so already-registered attendees know what to expect on arrival

## Test plan
- [ ] Confirm the RSVP section reads as closed on the deployed site
- [ ] Confirm the NDA-on-kiosk note still shows for registered attendees

🤖 Generated with [Claude Code](https://claude.com/claude-code)