### PR TITLE
Add Community Events page for member-submitted events

### DIFF
--- a/.claude/skills/community-event/SKILL.md
+++ b/.claude/skills/community-event/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: community-event
+description: Add an approved community-submitted event to the Community Events page
+user-invocable: true
+---
+
+# Community Event Skill
+
+Add an approved community-submitted event to `content/community.md`. These are external events (not BGNWG-hosted) that members of the community submit through the form on the page.
+
+## Before Writing
+
+Ask the user the following questions to gather details:
+
+1. **Which chapter?** (Boston / Bay Area)
+2. **Event title?** (e.g. "Robotics Talk at MIT")
+3. **Category?** (Robotics / Board Games / Tech & Community)
+4. **Date and time?** (e.g. "June 15, 2026 @ 6:00 PM")
+5. **Venue + address?** (venue name, street, city, state)
+6. **Host / organizer?** (person, club, or company running the event)
+7. **Short description?** (1–2 sentences)
+8. **RSVP / info link?** (URL to a Luma, Eventbrite, Meetup, or other landing page)
+
+## Entry Format
+
+Each entry is a `###` heading with a category badge, followed by When / Where / Host lines and a short description, then a link:
+
+```
+### Event Title <span class="badge badge-{category}">{emoji} {Category Label}</span>
+**When:** {date and time} \
+**Where:** {venue}, {address} \
+**Host:** {host} \
+{1–2 sentence description}
+
+[More info / RSVP →]({url})
+```
+
+### Category badge mapping
+
+| Category | Badge class | Emoji + label |
+|---|---|---|
+| Robotics | `badge-robotics` | `🤖 Robotics` |
+| Board Games | `badge-boardgames` | `🎲 Board Games` |
+| Tech & Community | `badge-tech` | `💻 Tech & Community` |
+
+## How to Add the Entry
+
+1. Read `content/community.md` to see the current state.
+2. Locate the correct chapter section (`## 🫘🌆 Boston` or `## 🌉🌅 Bay Area`).
+3. If the section still shows the empty-state line (`_No community events posted yet — ..._`), replace it with the new entry. Otherwise, insert the new entry above existing entries if it's sooner, or below if it's later — events are listed in chronological order (soonest first).
+4. Keep a blank line between entries.
+5. Do not touch the example `<!-- ... -->` comment block — leave it as a reference for future entries.
+
+## Cleanup
+
+When an event's date has passed, remove its entry from the page. If a chapter section has no upcoming events left, restore the empty-state line:
+
+```
+_No community events posted yet — be the first to submit yours below!_
+```
+
+## Notes
+
+- Only post approved submissions. Submissions come in via the Tally form embedded on the page; review them before adding here.
+- Keep descriptions short — 1–2 sentences max. Link out for full details.
+- If a submitted event clearly doesn't fit the audience (robotics / board games / adjacent tech) or the chapters (Boston / Bay Area), decline it rather than posting.

--- a/.claude/skills/community-event/SKILL.md
+++ b/.claude/skills/community-event/SKILL.md
@@ -61,6 +61,6 @@ _No community events posted yet — be the first to submit yours below!_
 
 ## Notes
 
-- Only post approved submissions. Submissions come in via the Tally form embedded on the page; review them before adding here.
+- Only post approved submissions. For now, submissions come in by email to contact@boardgamenightwg.com (or directly to the coordinator); review them before adding here.
 - Keep descriptions short — 1–2 sentences max. Link out for full details.
 - If a submitted event clearly doesn't fit the audience (robotics / board games / adjacent tech) or the chapters (Boston / Bay Area), decline it rather than posting.

--- a/.claude/skills/community-event/SKILL.md
+++ b/.claude/skills/community-event/SKILL.md
@@ -51,6 +51,17 @@ Each entry is a `###` heading with a category badge, followed by When / Where / 
 4. Keep a blank line between entries.
 5. Do not touch the example `<!-- ... -->` comment block — leave it as a reference for future entries.
 
+## Also Add to the Luma Calendar
+
+Every approved community event also goes on the **Board Game Night WG** Luma calendar, so it appears in the calendar embed on the home page.
+
+1. Go to the calendar admin: https://luma.com/calendar/manage/cal-v6H3Jm84BrwuOYb
+2. On the **Events** tab, click the **+** next to "Events".
+3. If the event has its own Luma page, choose **Add Existing Luma Event** and paste its Luma URL (preferred — pulls in the event's own image and details). Otherwise choose **Add External Event** and fill in the URL, name, location, host, and times.
+4. Confirm the event shows up under Upcoming with the right date.
+
+When an event is removed from the page (see Cleanup), it does not need to be removed from the Luma calendar — past events age out of the embed on their own.
+
 ## Cleanup
 
 When an event's date has passed, remove its entry from the page. If a chapter section has no upcoming events left, restore the empty-state line:

--- a/config.toml
+++ b/config.toml
@@ -36,6 +36,10 @@ name = "Past Events"
 url = "@/pastevents.md"
 
 [[extra.main_menu]]
+name = "Community Events"
+url = "@/community.md"
+
+[[extra.main_menu]]
 name = "FAQ"
 url = "@/faq.md"
 

--- a/content/community.md
+++ b/content/community.md
@@ -1,0 +1,34 @@
++++
+title = "🤝 Community Events"
++++
+
+A community-submitted list of upcoming robotics, board game, and adjacent tech events around Boston and the Bay Area. Have something to share? [Submit your event below](#submit-your-event) — we'll review and post approved submissions here.
+
+## 🫘🌆 Boston
+
+_No community events posted yet — be the first to submit yours below!_
+
+<!-- Example entry — copy and adapt when adding an approved submission:
+
+### Robotics Talk at MIT <span class="badge badge-robotics">🤖 Robotics</span>
+**When:** June 15, 2026 @ 6:00 PM \
+**Where:** MIT Stata Center, 32 Vassar St, Cambridge, MA \
+**Host:** MIT Robotics Club \
+A talk on the latest in legged locomotion, followed by an open lab tour.
+
+[More info / RSVP →](https://example.com)
+
+-->
+
+## 🌉🌅 Bay Area
+
+_No community events posted yet — be the first to submit yours below!_
+
+## Submit Your Event {#submit-your-event}
+
+Want to post an event here? Fill out the form below — we review each submission and post approved events on this page. Please submit at least two weeks in advance when possible.
+
+<!-- TODO: replace this placeholder with the Tally form embed snippet once the form is created. See https://tally.so/help/embed-forms for embed instructions. -->
+<div style="padding: 2rem; border: 2px dashed #bfcbda88; border-radius: 8px; text-align: center;">
+  <p><em>Submission form coming soon — check back shortly!</em></p>
+</div>

--- a/content/community.md
+++ b/content/community.md
@@ -6,7 +6,13 @@ A community-submitted list of upcoming robotics, board game, and adjacent tech e
 
 ## 🫘🌆 Boston
 
-_No community events posted yet — be the first to submit yours below!_
+### Revolute: Boston Physical AI Hackathon <span class="badge badge-robotics">🤖 Robotics</span>
+**When:** August 1–2, 2026 \
+**Where:** 325 Main St, Kendall Square, Cambridge, MA \
+**Host:** Nancy Ouyang · Fab Foundation \
+A two-day robotics + physical AI hackathon — each team gets a real robot arm to program, with $15k of robot hardware on hand. Space is limited to about 30 in-person participants, so apply early; mentors and co-organizers with a robotics background are also welcome.
+
+[More info / Apply →](https://revolutehack.com)
 
 <!-- Example entry — copy and adapt when adding an approved submission:
 

--- a/content/community.md
+++ b/content/community.md
@@ -32,9 +32,4 @@ _No community events posted yet — be the first to submit yours below!_
 
 ## Submit Your Event {#submit-your-event}
 
-Want to post an event here? Fill out the form below — we review each submission and post approved events on this page. Please submit at least two weeks in advance when possible.
-
-<!-- TODO: replace this placeholder with the Tally form embed snippet once the form is created. See https://tally.so/help/embed-forms for embed instructions. -->
-<div style="padding: 2rem; border: 2px dashed #bfcbda88; border-radius: 8px; text-align: center;">
-  <p><em>Submission form coming soon — check back shortly!</em></p>
-</div>
+Want to post an event here? For now, email us at [contact@boardgamenightwg.com](mailto:contact@boardgamenightwg.com) with the details — title, date and time, venue and address, host, a short description, and a link. We review each submission and post approved events on this page. Please reach out at least two weeks in advance when possible.

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -607,3 +607,52 @@ body[data-theme="dark"] .logo-dark  { display: inline; }
         margin-left: 0.4rem;
     }
 }
+
+.badge {
+    display: inline-block;
+    padding: 0.15em 0.65em;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 600;
+    margin-left: 0.4em;
+    vertical-align: middle;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    line-height: 1.5;
+}
+
+.badge-robotics {
+    background-color: #DCEEFB;
+    color: #0967D2;
+    border-color: #BCD9F1;
+}
+
+.badge-boardgames {
+    background-color: #FFE4C7;
+    color: #D35400;
+    border-color: #FFCBA4;
+}
+
+.badge-tech {
+    background-color: #E9D8FD;
+    color: #6B46C1;
+    border-color: #D6BCFA;
+}
+
+body[data-theme="dark"] .badge-robotics {
+    background-color: #1A365D;
+    color: #BEE3F8;
+    border-color: #2C5282;
+}
+
+body[data-theme="dark"] .badge-boardgames {
+    background-color: #5C2E0A;
+    color: #FED7AA;
+    border-color: #7B3F0B;
+}
+
+body[data-theme="dark"] .badge-tech {
+    background-color: #322659;
+    color: #D6BCFA;
+    border-color: #4C3585;
+}


### PR DESCRIPTION
## Summary
- New **Community Events** page (`content/community.md`) where members can submit robotics, board game, and adjacent tech events around Boston and the Bay Area.
- Added to the main nav between "Past Events" and "FAQ".
- Category badge styles (Robotics / Board Games / Tech & Community) appended to `static/styles/main.css`, including dark-mode variants.
- New `community-event` skill walks through adding approved entries.
- First entry included: **Revolute: Boston Physical AI Hackathon** (Aug 1–2, Kendall Square), submitted by Nancy Ouyang.

## Submission flow (manual review)
For now, submissions come in by email to contact@boardgamenightwg.com — the page says so directly. Approved entries are added manually using the new skill. A proper form (Tally or similar) can come later if volume warrants it.

## Test plan
- [x] `zola build` passes (verified locally — anchor link check passed)
- [ ] Community Events appears in top nav
- [ ] Page renders the Revolute entry and the Bay Area empty state
- [ ] Category badge styles render correctly in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)