### PR TITLE
Reset Boston page to TBD after Jun 23 event

### DIFF
--- a/content/boston.md
+++ b/content/boston.md
@@ -4,47 +4,7 @@ title = "🫘🌆 Boston"
 <!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
 
 ## Where
-<a href="https://picklerobot.com/">
-  <!-- light version -->
-  <img
-    src="/images/logos/Pickle_Logo_OffBlack.svg"
-    alt="Pickle Robot Company Logo"
-    class="logo-light"
-  >
-  <!-- dark version -->
-  <img
-    src="/images/logos/Pickle_Logo_PickleGreen.svg"
-    alt="Pickle Robot Company Logo"
-    class="logo-dark"
-  >
-</a>
-
-**Pickle Robot Company** \
-**465 Medford Street, Suite 102** \
-**Charlestown, MA 02129**
-
-Pickle Robot Company will provide pizza, snacks, and both non-alcoholic and alcoholic beverages. \
-Games will be provided but feel free to bring your own to share!
-
-Photographs are welcome — and encouraged!
+TBD
 
 ## When
-June 23, 2026 @ 6:00 pm - 8:45 pm
-
-## RSVP
-
-**Registration is now closed — we've reached capacity.**
-
-Thank you to everyone who RSVP'd! We're at full capacity for this event and are no longer accepting new registrations.
-
-<iframe src="https://lu.ma/embed-checkout/1etgvzvp" width="100%" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
-
-## Access
-Pickle Robot Company's office is located at 465 Medford Street in Charlestown. Upon arrival, enter the lobby and turn right. Pickle’s office is just down the hallway on the first floor, on the right-hand side.
-
-You’re welcome to park anywhere in the lot directly adjacent to 465 Medford Street.
-If you arrive after 6:00 pm, send a text to \
-
-(617) 744-9296 \
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d9105.799912879938!2d-71.08038295003053!3d42.3773025384585!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89e37714d362b919%3A0x209f2898424708c!2sPickle%20Robot%20Company!5e0!3m2!1sen!2sus!4v1755803731529!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+TBD

--- a/content/boston.md
+++ b/content/boston.md
@@ -1,7 +1,7 @@
 +++
 title = "🫘🌆 Boston"
 +++
-<!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
+[![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston)
 
 ## Where
 TBD


### PR DESCRIPTION
The June 23, 2026 Pickle Robot event has passed and was archived to Past Events in #71. This blanks the Boston **When** and **Where** back to `TBD` (matching the Bay Area page) until the next event is locked in.

Merging this triggers the Zola deploy, so the live Boston page stops showing the past event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)