### PR TITLE
Add Reframe Systems event for Boston July 2026

### DIFF
--- a/content/boston.md
+++ b/content/boston.md
@@ -5,17 +5,19 @@ title = "🫘🌆 Boston"
 
 ## Where
 <a href="https://www.reframe.systems/">
-  <!-- light version -->
+  <!-- light mode: dark-ink logo on light background -->
   <img
-    src="/images/logos/reframe-systems.png"
+    src="/images/logos/reframe-systems-vertical-light.png"
     alt="Reframe Systems Logo"
     class="logo-light"
+    style="max-width: 300px; margin: 0 auto;"
   >
-  <!-- dark version (TBD: swap in Reframe Logo Vertical Dark.png from host) -->
+  <!-- dark mode: white-ink logo on dark background -->
   <img
-    src="/images/logos/reframe-systems.png"
+    src="/images/logos/reframe-systems-vertical-dark.png"
     alt="Reframe Systems Logo"
     class="logo-dark"
+    style="max-width: 300px; margin: 0 auto;"
   >
 </a>
 

--- a/content/boston.md
+++ b/content/boston.md
@@ -37,6 +37,8 @@ TBD: RSVP link (Luma) \
 TBD: RSVP deadline \
 
 ## Access
+Andover is a bit of a drive for many of us, so consider teaming up and arranging a carpool with other attendees. Coordinate on the RSVP page or the <a href="https://groups.google.com/g/boardgamenightwg">Google Group</a>.
+
 TBD: Suite / floor / building entry instructions \
 TBD: Directions quirks and parking recommendations \
 TBD: Guest list / security form / NDA requirements and submission deadline \

--- a/content/boston.md
+++ b/content/boston.md
@@ -33,7 +33,7 @@ TBD: Alcohol policy \
 July 22, 2026 @ 6:00 pm - 8:45 pm
 
 ## RSVP
-<
+<a
   href="https://luma.com/event/evt-0BXLk5tNr9INnT0"
   class="luma-checkout--button"
   data-luma-action="checkout"

--- a/content/boston.md
+++ b/content/boston.md
@@ -33,7 +33,19 @@ TBD: Alcohol policy \
 July 22, 2026 @ 6:00 pm - 8:45 pm
 
 ## RSVP
-TBD: RSVP link (Luma) \
+Please RSVP at the <a href="https://luma.com/event/evt-0BXLk5tNr9INnT0">Luma here</a>
+
+<a
+  href="https://luma.com/event/evt-0BXLk5tNr9INnT0"
+  class="luma-checkout--button"
+  data-luma-action="checkout"
+  data-luma-event-id="evt-0BXLk5tNr9INnT0"
+>
+  Register for Event
+</a>
+
+<script id="luma-checkout" src="https://embed.lu.ma/checkout-button.js"></script>
+
 TBD: RSVP deadline \
 
 ## Access

--- a/content/boston.md
+++ b/content/boston.md
@@ -33,9 +33,7 @@ TBD: Alcohol policy \
 July 22, 2026 @ 6:00 pm - 8:45 pm
 
 ## RSVP
-Please RSVP at the <a href="https://luma.com/event/evt-0BXLk5tNr9INnT0">Luma here</a>
-
-<a
+<
   href="https://luma.com/event/evt-0BXLk5tNr9INnT0"
   class="luma-checkout--button"
   data-luma-action="checkout"

--- a/content/boston.md
+++ b/content/boston.md
@@ -4,14 +4,14 @@ title = "🫘🌆 Boston"
 <!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
 
 ## Where
-<a href="https://reframe.systems/">
+<a href="https://www.reframe.systems/">
   <!-- light version -->
   <img
     src="/images/logos/reframe-systems.png"
     alt="Reframe Systems Logo"
     class="logo-light"
   >
-  <!-- dark version (TBD: dark-background variant from host) -->
+  <!-- dark version (TBD: swap in Reframe Logo Vertical Dark.png from host) -->
   <img
     src="/images/logos/reframe-systems.png"
     alt="Reframe Systems Logo"
@@ -23,16 +23,18 @@ title = "🫘🌆 Boston"
 **30 Lowell Junction Road** \
 **Andover, MA 01810**
 
-Reframe Systems will provide food and drinks. \
+Reframe Systems will provide food and snacks. \
+Beverages are BYOB, and the host is hoping to provide some as well. \
 Games will be provided but feel free to bring your own to share!
 
-TBD: Photography / social media policy \
-TBD: Alcohol policy \
+You are welcome to take photos and videos to share with friends and family, but please do not post anything on social media that shows technology in the background.
 
 ## When
 July 22, 2026 @ 6:00 pm - 8:45 pm
 
 ## RSVP
+Space is limited to about 50 guests, so please RSVP early. Please RSVP by Monday, July 20 so the host can plan snacks. A few extra day-of are fine, it is not strict.
+
 <a
   href="https://luma.com/event/evt-0BXLk5tNr9INnT0"
   class="luma-checkout--button"
@@ -44,14 +46,13 @@ July 22, 2026 @ 6:00 pm - 8:45 pm
 
 <script id="luma-checkout" src="https://embed.lu.ma/checkout-button.js"></script>
 
-TBD: RSVP deadline \
+All attendees must also complete Reframe's visitor form, either ahead of time or when you arrive: <a href="https://visitor.reframe.quest/">visitor.reframe.quest</a>
 
 ## Access
 Andover is a bit of a drive for many of us, so consider teaming up and arranging a carpool with other attendees. Coordinate on the RSVP page or the <a href="https://groups.google.com/g/boardgamenightwg">Google Group</a>.
 
-TBD: Suite / floor / building entry instructions \
-TBD: Directions quirks and parking recommendations \
-TBD: Guest list / security form / NDA requirements and submission deadline \
-TBD: Day-of contact name and phone number \
+Reframe Systems is the only building in the parking lot. Look for the big **30** on the building and enter through the main **green door**. Park right in front of the building.
+
+If you have trouble getting in on the day of the event, contact Dave Powers at (774) 502-6270.
 
 <iframe src="https://maps.google.com/maps?q=30+Lowell+Junction+Road+Andover+MA+01810&output=embed" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/content/boston.md
+++ b/content/boston.md
@@ -1,10 +1,45 @@
 +++
 title = "🫘🌆 Boston"
 +++
-[![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston)
+<!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
 
 ## Where
-TBD
+<a href="https://reframe.systems/">
+  <!-- light version -->
+  <img
+    src="/images/logos/reframe-systems.png"
+    alt="Reframe Systems Logo"
+    class="logo-light"
+  >
+  <!-- dark version (TBD: dark-background variant from host) -->
+  <img
+    src="/images/logos/reframe-systems.png"
+    alt="Reframe Systems Logo"
+    class="logo-dark"
+  >
+</a>
+
+**Reframe Systems** \
+**30 Lowell Junction Road** \
+**Andover, MA 01810**
+
+Reframe Systems will provide food and drinks. \
+Games will be provided but feel free to bring your own to share!
+
+TBD: Photography / social media policy \
+TBD: Alcohol policy \
 
 ## When
-TBD
+July 22, 2026 @ 6:00 pm - 8:45 pm
+
+## RSVP
+TBD: RSVP link (Luma) \
+TBD: RSVP deadline \
+
+## Access
+TBD: Suite / floor / building entry instructions \
+TBD: Directions quirks and parking recommendations \
+TBD: Guest list / security form / NDA requirements and submission deadline \
+TBD: Day-of contact name and phone number \
+
+<iframe src="https://maps.google.com/maps?q=30+Lowell+Junction+Road+Andover+MA+01810&output=embed" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>

--- a/static/images/logos/reframe-systems-vertical-dark.png
+++ b/static/images/logos/reframe-systems-vertical-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:164c63e842efc0930e0d3d733048e11a65e9f66ed470645d6853f1f67f89dd6c
+size 17788

--- a/static/images/logos/reframe-systems-vertical-light.png
+++ b/static/images/logos/reframe-systems-vertical-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:175da22a81598dff1e6fc1246eea04d5b2f24a316713acc722d9c66af2c645d5
+size 19648


### PR DESCRIPTION
Adds the Boston chapter's next event: **Reframe Systems** in Andover, MA on **Wednesday, July 22, 2026, 6:00 to 8:45 pm**.

## Confirmed
- Venue: Reframe Systems, 30 Lowell Junction Road, Andover, MA 01810
- Date/time: July 22, 2026 @ 6:00 pm - 8:45 pm
- Food and drinks provided by the host
- Existing `reframe-systems.png` logo used (linked to reframe.systems)
- Google Maps embed via address query

## Still TBD (collecting from host via questionnaire)
- RSVP link (Luma) and RSVP deadline
- Photography / social media policy
- Alcohol policy
- Suite / floor / building entry instructions
- Directions quirks, parking recommendations
- Guest list / security form / NDA requirements and submission deadline
- Day-of contact name and phone number
- Dark-background logo variant (current logo is dark-text; reused for both modes for now)

TBD items render as visible placeholders on the page so they double as a checklist while the host reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)