### PR TITLE
Reset Boston page to TBD after Jul 22 event

### DIFF
--- a/content/boston.md
+++ b/content/boston.md
@@ -1,60 +1,10 @@
 +++
 title = "🫘🌆 Boston"
 +++
-<!-- [![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston) -->
+[![venue logo](/images/boston/faneuilhall.png)](https://boardgamenightwg.com/boston)
 
 ## Where
-<a href="https://www.reframe.systems/">
-  <!-- light mode: dark-ink logo on light background -->
-  <img
-    src="/images/logos/reframe-systems-vertical-light.png"
-    alt="Reframe Systems Logo"
-    class="logo-light"
-    style="max-width: 300px; margin: 0 auto;"
-  >
-  <!-- dark mode: white-ink logo on dark background -->
-  <img
-    src="/images/logos/reframe-systems-vertical-dark.png"
-    alt="Reframe Systems Logo"
-    class="logo-dark"
-    style="max-width: 300px; margin: 0 auto;"
-  >
-</a>
-
-**Reframe Systems** \
-**30 Lowell Junction Road** \
-**Andover, MA 01810**
-
-Reframe Systems will provide food and snacks. \
-Beverages are BYOB, and the host is hoping to provide some as well. \
-Games will be provided but feel free to bring your own to share!
-
-You are welcome to take photos and videos to share with friends and family, but please do not post anything on social media that shows technology in the background.
+TBD
 
 ## When
-July 22, 2026 @ 6:00 pm - 8:45 pm
-
-## RSVP
-Space is limited to about 50 guests, so please RSVP early. Please RSVP by Monday, July 20 so the host can plan snacks. A few extra day-of are fine, it is not strict.
-
-<a
-  href="https://luma.com/event/evt-0BXLk5tNr9INnT0"
-  class="luma-checkout--button"
-  data-luma-action="checkout"
-  data-luma-event-id="evt-0BXLk5tNr9INnT0"
->
-  Register for Event
-</a>
-
-<script id="luma-checkout" src="https://embed.lu.ma/checkout-button.js"></script>
-
-All attendees must also complete Reframe's visitor form, either ahead of time or when you arrive: <a href="https://visitor.reframe.quest/">visitor.reframe.quest</a>
-
-## Access
-Andover is a bit of a drive for many of us, so consider teaming up and arranging a carpool with other attendees. Coordinate on the RSVP page or the <a href="https://groups.google.com/g/boardgamenightwg">Google Group</a>.
-
-Reframe Systems is the only building in the parking lot. Look for the big **30** on the building and enter through the main **green door**. Park right in front of the building.
-
-If you have trouble getting in on the day of the event, contact Dave Powers at (774) 502-6270.
-
-<iframe src="https://maps.google.com/maps?q=30+Lowell+Junction+Road+Andover+MA+01810&output=embed" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+TBD


### PR DESCRIPTION
The July 22 Reframe Systems event has passed. The next confirmed event (BU RASTIC) isn't until September 9 and an August host is still being sought, so the Boston page goes back to TBD in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)