### PR TITLE
Update Revolute community entry to match its Luma listing

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -8,8 +8,8 @@ A community-submitted list of upcoming robotics, board game, and adjacent tech e
 
 ### Revolute: Boston Physical AI Hackathon <span class="badge badge-robotics">🤖 Robotics</span>
 **When:** August 1–2, 2026 \
-**Where:** 325 Main St, Kendall Square, Cambridge, MA \
-**Host:** Nancy Ouyang · Fab Foundation \
+**Where:** FabLab Kendall, 325 Main St, Cambridge, MA 02142 \
+**Host:** Revolute Hackathon team · Nancy Ouyang \
 A two-day robotics + physical AI hackathon — each team gets a real robot arm to program, with $15k of robot hardware on hand. Space is limited to about 30 in-person participants, so apply early; mentors and co-organizers with a robotics background are also welcome.
 
 [More info / Apply →](https://revolutehack.com)


### PR DESCRIPTION
Syncs the Revolute Hackathon entry on the Community Events page with its Luma listing (https://luma.com/kxq4yxr8): venue is FabLab Kendall, 325 Main St, Cambridge, MA 02142, and the host line now credits the Revolute Hackathon team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)